### PR TITLE
[fix]注文、カート微修正

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -16,7 +16,7 @@ class Public::CartItemsController < ApplicationController
         redirect_to public_cart_items_path
       else
         @carts_items = @customer.cart_items.all
-        render public_cart_items_path
+        redirect_to public_cart_items_path
       end
     else
       @current_item.number += params[:number].to_i

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -52,7 +52,8 @@ before_action :set_customer
         render :complete
     
       else
-        redirect_to root_path
+        flash[:notice] = "カートの中身がありません"
+        redirect_to public_cart_items_path
       end
     end
 
@@ -81,7 +82,8 @@ before_action :set_customer
       elsif @add.to_i == 2
         @sta = params[:order][:id].to_i
         @address = Delivery.find(@sta)
-        @order.postcode = @address.address
+        @order.address = @address.address
+        @order.postcode = @address.postcode
         @order.addressee = @address.addressee
       elsif @add.to_i == 3
         @order.postcode = params[:order][:postcode]

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -4,4 +4,5 @@ class CartItem < ApplicationRecord
 	belongs_to :product
 	validates :customer_id, presence: true
 	validates :product_id, presence: true
+	validates :number, presence: true
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
 
     <% if flash[:notice] %>
     <div class= "alert alert-success row" style="text-align: center;">
-      <%= flash[:notice]%>
+      <%= flash[:notice] %>
     </div>
     <% end %>
 

--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -21,7 +21,7 @@
 			</div>
 
 				<div class="row">
-					<%= form_with model: @cart_item ,local: true, url: public_cart_items_path(@cart_item) do |f| %>
+					<%= form_with model: @cart_item ,local: true, url: public_cart_items_path(@cart_item),method: :post do |f| %>
 						<div class="col-xs-offset-6 col-xs-2">
 							<%= f.number_field :number, min: 1, max: 10 %>個
 						</div>


### PR DESCRIPTION
商品個数空でカート送るとエラー
カート空でも決済完了してしまう
注文確認時郵便番号表示されない

上記解消しました。